### PR TITLE
Fixed bug with youtube activity.

### DIFF
--- a/src/main/java/gov/wa/wsdot/mobile/client/activities/socialmedia/youtube/YouTubeActivity.java
+++ b/src/main/java/gov/wa/wsdot/mobile/client/activities/socialmedia/youtube/YouTubeActivity.java
@@ -140,7 +140,7 @@ public class YouTubeActivity extends MGWTAbstractActivity implements
 					int numEntries = result.getItems().length();
 					for (int i = 0; i < numEntries; i++) {
 					    // If we don't have a standard sized 640x480 video available, move on
-					    if (result.getItems().get(i).getSnippet().getThumbnails().getStandard().getUrl() == null) {
+					    if (result.getItems().get(i).getSnippet().getThumbnails().getStandard() == null) {
 					        continue;
 					    } else {
     					    item = new YouTubeItem();


### PR DESCRIPTION
When checking for standard thumbnail we called .getUrl() on a possible null field causing an error. ~~I noticed the bug when I tried to load the youtube feed on my personal iPhone.~~  (This version hasn't been pushed to the app store) I think this fixes the problem. 