### PR TITLE
Fixed bug where ad banner covers toolbar on rotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Ad banner covers toolbar on orientation change.
 
 ## [4.2.0] - 2016-04-12
 ### Added 

--- a/src/main/java/gov/wa/wsdot/mobile/client/MobileAppEntryPoint.java
+++ b/src/main/java/gov/wa/wsdot/mobile/client/MobileAppEntryPoint.java
@@ -76,7 +76,6 @@ public class MobileAppEntryPoint implements EntryPoint {
 
     static ClientFactory staticFactory;
     final static AdMob adMob = GWT.create(AdMob.class);
-    static boolean voEventSent = false;
 
     private void start() {
 
@@ -127,7 +126,7 @@ public class MobileAppEntryPoint implements EntryPoint {
         MGWT.addOrientationChangeHandler(new OrientationChangeHandler() {
             @Override
             public void onOrientationChanged(OrientationChangeEvent event) {
-                accessibility.isVoiceOverRunning();
+                accessibility.isVoiceOverRunning(false);
             }
         });
 
@@ -135,7 +134,8 @@ public class MobileAppEntryPoint implements EntryPoint {
 
 		if (MGWT.getOsDetection().isIOs()){
 			exportInitAds();
-        	accessibility.isVoiceOverRunning();
+            exportVoiceOverEvent();
+        	accessibility.isVoiceOverRunning(true);
 		}else{
 			// Initialize and configure AdMob plugin
 			final AdMob adMob = GWT.create(AdMob.class);
@@ -168,14 +168,6 @@ public class MobileAppEntryPoint implements EntryPoint {
 
         if (VoiceOverOn){
             options.setPosition(AdPosition.BOTTOM_CENTER.getPosition());
-
-            // Only track VO event on first load.
-            if (Consts.ANALYTICS_ENABLED) {
-                if (!voEventSent){
-                    staticFactory.getAnalytics().trackEvent(Consts.EVENT_ACCESSIBILITY, "VoiceOver On", null);
-                    voEventSent = true;
-                }
-            }
         }
 		adMob.createBanner(options);
 	}
@@ -185,6 +177,24 @@ public class MobileAppEntryPoint implements EntryPoint {
      */
     public static native void exportInitAds() /*-{
         $wnd.initAds = $entry(@gov.wa.wsdot.mobile.client.MobileAppEntryPoint::initAds(Z));
+    }-*/;
+
+
+    /**
+     * Sends VoiceOver event to GA
+     *
+     * @param voiceOverOn
+     */
+    public static void voiceOverEvent(boolean voiceOverOn){
+        if (voiceOverOn){
+            if (Consts.ANALYTICS_ENABLED) {
+                staticFactory.getAnalytics().trackEvent(Consts.EVENT_ACCESSIBILITY, "VoiceOver On", null);
+            }
+        }
+    }
+
+    public static native void exportVoiceOverEvent() /*-{
+        $wnd.voiceOverEvent = $entry(@gov.wa.wsdot.mobile.client.MobileAppEntryPoint::voiceOverEvent(Z));
     }-*/;
 
 	private void buildDisplay(final ClientFactory clientFactory, final PhoneGap phoneGap) {

--- a/src/main/java/gov/wa/wsdot/mobile/client/plugins/accessibility/Accessibility.java
+++ b/src/main/java/gov/wa/wsdot/mobile/client/plugins/accessibility/Accessibility.java
@@ -29,7 +29,7 @@ public interface Accessibility extends PhoneGapPlugin{
     /**
      *  Calls MobileAccessibility.isVoiceOverRunning(callback)
      */
-    public void isVoiceOverRunning();
+    public void isVoiceOverRunning(boolean analytics);
 
     /**
      *  Sends a screen change notification to VoiceOver

--- a/src/main/java/gov/wa/wsdot/mobile/client/plugins/accessibility/AccessibilityBrowsweImpl.java
+++ b/src/main/java/gov/wa/wsdot/mobile/client/plugins/accessibility/AccessibilityBrowsweImpl.java
@@ -29,7 +29,7 @@ public class AccessibilityBrowsweImpl implements Accessibility {
     public void initialize() {}
 
     @Override
-    public void isVoiceOverRunning() {}
+    public void isVoiceOverRunning(boolean analytics) {}
 
     @Override
     public void postScreenChangeNotification() {}

--- a/src/main/java/gov/wa/wsdot/mobile/client/plugins/accessibility/AccessibilityCordovaImpl.java
+++ b/src/main/java/gov/wa/wsdot/mobile/client/plugins/accessibility/AccessibilityCordovaImpl.java
@@ -42,10 +42,24 @@ public class AccessibilityCordovaImpl implements Accessibility {
 
 
     @Override
-    public native void isVoiceOverRunning() /*-{
-        $wnd.MobileAccessibility.isVoiceOverRunning($wnd.initAds);
-    }-*/;
+    public void isVoiceOverRunning(boolean analytics){
+        if (!initialized) {
+            throw new IllegalStateException("you have to initialize MobileAccessibility plugin before using it");
+        }
+        isVoiceOverRunningNative(analytics);
+    }
 
+    private native void isVoiceOverRunningNative(boolean analytics) /*-{
+
+        function callback(isVoiceOverRunning){
+            $wnd.initAds(isVoiceOverRunning);
+            if (analytics){
+                $wnd.voiceOverEvent();
+            }
+        }
+
+        $wnd.MobileAccessibility.isVoiceOverRunning(callback);
+    }-*/;
 
     @Override
     public void postScreenChangeNotification() {

--- a/src/main/java/gov/wa/wsdot/mobile/client/plugins/accessibility/AccessibilityCordovaImpl.java
+++ b/src/main/java/gov/wa/wsdot/mobile/client/plugins/accessibility/AccessibilityCordovaImpl.java
@@ -54,7 +54,7 @@ public class AccessibilityCordovaImpl implements Accessibility {
         function callback(isVoiceOverRunning){
             $wnd.initAds(isVoiceOverRunning);
             if (analytics){
-                $wnd.voiceOverEvent();
+                $wnd.voiceOverEvent(isVoiceOverRunning);
             }
         }
 


### PR DESCRIPTION
issue #45 
##### Changes
* Added an orientation change listener to MGWT that will call isVoiceOverRunning() to restart ads.
* Moved the init ads and google analytics VoiceOver tracking logic into separate functions. 
* isVoiceOverRunning() now takes a boolean that determines if it will send a VoiceOver on event to Google analytics.